### PR TITLE
fix: Add contents permission to GitHub token

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -29,6 +29,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: apache/logging-parent/.github/workflows/process-dependabot-reusable.yaml@feat/dependabot-add-changelog2
     permissions:
+      contents: write
       pull-requests: write
     secrets:
       AUTO_MERGE_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Apparently `contents` is also required to turn on "auto-merge".
