### PR TITLE
fix: Use `github.head_ref`

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -39,3 +39,4 @@ jobs:
     with:
       user_name: 'Release Manager'
       user_email: bot@copernik.eu
+      ref: ${{ github.head_ref }}


### PR DESCRIPTION
Use `github.head_ref` instead of `github.ref` for the Dependabot workflow.

